### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ RESTful web APIs in Flask.
 
 At the core, there's a Pager class, which does the necessary calculations
 to split Python lists, SQLAlchemy queries etc. into pages while providing
-a lot of auxilliary data for displaying pagers.
+a lot of auxiliary data for displaying pagers.
 
 


### PR DESCRIPTION
pudo, I've corrected a typographical error in the documentation of the [apikit](https://github.com/pudo/apikit) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
